### PR TITLE
Add StorageExt trait

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -31,6 +31,7 @@ use sawtooth_sdk::consensus::{
 use config::{self, RaftEngineConfig};
 use ticker;
 use node::SawtoothRaftNode;
+use storage::StorageExt;
 
 
 pub struct RaftEngine {
@@ -110,7 +111,7 @@ impl Engine for RaftEngine {
 }
 
 // Returns whether the engine should continue
-fn handle_update(node: &mut SawtoothRaftNode, update: Update) -> bool {
+fn handle_update<S: StorageExt>(node: &mut SawtoothRaftNode<S>, update: Update) -> bool {
     match update {
         Update::BlockNew(block) => node.on_block_new(block),
         Update::BlockValid(block_id) => node.on_block_valid(block_id),

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ use sawtooth_sdk::consensus::zmq_driver::ZmqDriver;
 mod config;
 mod engine;
 mod node;
+mod storage;
 mod ticker;
 
 fn main() {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use raft::{Error, eraftpb::{Entry, HardState, Snapshot}, storage::{MemStorage, Storage}};
+
+/// Extends the storage trait to include methods used by SawtoothRaftNode and provided by the
+/// MemStorage type.
+pub trait StorageExt: Storage {
+    /// set_hardstate saves the current HardState.
+    fn set_hardstate(&self, hs: HardState);
+
+    /// apply_snapshot overwrites the contents of this Storage object with those of the given
+    /// snapshot.
+    fn apply_snapshot(&self, snapshot: Snapshot) -> Result<(), Error>;
+
+    /// compact discards all log entries prior to compact_index. It is the application's
+    /// responsibility to not attempt to compact an index greater than RaftLog.applied.
+    fn compact(&self, compact_index: u64) -> Result<(), Error>;
+
+    /// Append the new entries to storage. TODO: ensure the entries are continuous and
+    /// entries[0].get_index() > self.entries[0].get_index()
+    fn append(&self, ents: &[Entry]) -> Result<(), Error>;
+}
+
+impl StorageExt for MemStorage {
+    fn set_hardstate(&self, hs: HardState) {
+        self.wl().set_hardstate(hs)
+    }
+
+    fn apply_snapshot(&self, snapshot: Snapshot) -> Result<(), Error> {
+        self.wl().apply_snapshot(snapshot)
+    }
+
+    fn compact(&self, compact_index: u64) -> Result<(), Error> {
+        self.wl().compact(compact_index)
+    }
+
+    fn append(&self, ents: &[Entry]) -> Result<(), Error> {
+        self.wl().append(ents)
+    }
+}

--- a/tests/test_liveness.yaml
+++ b/tests/test_liveness.yaml
@@ -74,7 +74,7 @@ services:
           config-genesis.batch config.batch && \
         mv /etc/sawtooth/keys/validator-* /shared_keys && \
         echo $$(cat /etc/sawtooth/keys/validator.pub); \
-        sawtooth-validator \
+        sawtooth-validator -v \
             --endpoint tcp://validator-1:8800 \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
@@ -98,7 +98,7 @@ services:
     command: "bash -c \"\
         while true; do if [ -e /shared_keys/validator-2.pub ]; then mv /shared_keys/validator-2.priv /etc/sawtooth/keys/validator.priv && mv /shared_keys/validator-2.pub /etc/sawtooth/keys/validator.pub; break; fi; sleep 0.5; done; \
         echo $$(cat /etc/sawtooth/keys/validator.pub); \
-        sawtooth-validator \
+        sawtooth-validator -v \
             --endpoint tcp://validator-2:8800 \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \
@@ -122,7 +122,7 @@ services:
     command: "bash -c \"\
         while true; do if [ -e /shared_keys/validator-3.pub ]; then mv /shared_keys/validator-3.priv /etc/sawtooth/keys/validator.priv && mv /shared_keys/validator-3.pub /etc/sawtooth/keys/validator.pub; break; fi; sleep 0.5; done; \
         echo $$(cat /etc/sawtooth/keys/validator.pub); \
-        sawtooth-validator \
+        sawtooth-validator -v \
             --endpoint tcp://validator-3:8800 \
             --bind component:tcp://eth0:4004 \
             --bind network:tcp://eth0:8800 \


### PR DESCRIPTION
Create a trait that extends the Storage trait and mirrors the methods on
MemStorage used by Sawtooth Raft. This makes replacing the
implementation with persistent storage simpler.

Based on #2 