### PR TITLE
Update raft tests to use Sawtooth debs

### DIFF
--- a/tests/sawtooth-raft-test.dockerfile
+++ b/tests/sawtooth-raft-test.dockerfile
@@ -25,30 +25,16 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly xenial univers
     libssl-dev \
     gcc \
     git \
-    libzmq3-dev \
-    openssl \
     pkg-config \
     python3 \
     python3-sawtooth-cli \
+    python3-sawtooth-rest-api \
+    python3-sawtooth-settings \
+    python3-sawtooth-validator \
     python3-requests \
     python3-nose2 \
+    sawtooth-smallbank-workload \
+    sawtooth-smallbank-tp-go \
     unzip \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
-
-RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
- && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
- && rm protoc-3.5.1-linux-x86_64.zip
-
-RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
- && chmod +x /usr/bin/rustup-init \
- && rustup-init -y
-
-ENV PATH=$PATH:/protoc3/bin:/project/sawtooth-core/bin:/root/.cargo/bin \
-    CARGO_INCREMENTAL=0
-
-RUN git clone https://github.com/hyperledger/sawtooth-core
-
-WORKDIR /sawtooth-core/perf
-
-RUN cd smallbank_workload && cargo build

--- a/tests/test_liveness.yaml
+++ b/tests/test_liveness.yaml
@@ -42,11 +42,14 @@ services:
     command: "bash -c \"\
       sawtooth keygen smallbank-key; \
       while true; do curl -s http://rest-api-1:8008/state | grep -q head; if [ $$? -eq 0 ]; then break; fi; sleep 0.5; done; \
-      /sawtooth-core/perf/smallbank_workload/target/debug/smallbank-workload load --key /root/.sawtooth/keys/smallbank-key.priv --rate 1 --target http://rest-api-1:8008,http://rest-api-2:8008,http://rest-api-3:8008 \
+      smallbank-workload load --key /root/.sawtooth/keys/smallbank-key.priv --rate 1 --target http://rest-api-1:8008,http://rest-api-2:8008,http://rest-api-3:8008 \
       \""
 
   validator-1:
-    image: hyperledger/sawtooth-validator:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     volumes:
       - keys:/shared_keys
     expose:
@@ -83,7 +86,10 @@ services:
     stop_signal: SIGKILL
 
   validator-2:
-    image: hyperledger/sawtooth-validator:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     volumes:
       - keys:/shared_keys
     expose:
@@ -104,7 +110,10 @@ services:
     stop_signal: SIGKILL
 
   validator-3:
-    image: hyperledger/sawtooth-validator:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     volumes:
       - keys:/shared_keys
     expose:
@@ -158,7 +167,10 @@ services:
     stop_signal: SIGKILL
 
   rest-api-1:
-    image: hyperledger/sawtooth-rest-api:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     expose:
       - 4004
       - 8008
@@ -166,7 +178,10 @@ services:
     stop_signal: SIGKILL
 
   rest-api-2:
-    image: hyperledger/sawtooth-rest-api:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     expose:
       - 4004
       - 8008
@@ -174,7 +189,10 @@ services:
     stop_signal: SIGKILL
 
   rest-api-3:
-    image: hyperledger/sawtooth-rest-api:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     expose:
       - 4004
       - 8008
@@ -182,42 +200,60 @@ services:
     stop_signal: SIGKILL
 
   smallbank-tp-1:
-    image: hyperledger/sawtooth-smallbank-tp-go:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     expose:
       - 4004
     command: smallbank-tp-go -C tcp://validator-1:4004 --max-queue-size 1024 --worker-thread-count 32
     stop_signal: SIGKILL
 
   smallbank-tp-2:
-    image: hyperledger/sawtooth-smallbank-tp-go:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     expose:
       - 4004
     command: smallbank-tp-go -C tcp://validator-2:4004 --max-queue-size 1024 --worker-thread-count 32
     stop_signal: SIGKILL
 
   smallbank-tp-3:
-    image: hyperledger/sawtooth-smallbank-tp-go:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     expose:
       - 4004
     command: smallbank-tp-go -C tcp://validator-3:4004 --max-queue-size 1024 --worker-thread-count 32
     stop_signal: SIGKILL
 
   settings-tp-1:
-    image: hyperledger/sawtooth-settings-tp:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     expose:
       - 4004
     command: settings-tp -C tcp://validator-1:4004 -v
     stop_signal: SIGKILL
 
   settings-tp-2:
-    image: hyperledger/sawtooth-settings-tp:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     expose:
       - 4004
     command: settings-tp -C tcp://validator-2:4004
     stop_signal: SIGKILL
 
   settings-tp-3:
-    image: hyperledger/sawtooth-settings-tp:latest
+    image: sawtooth-raft-test:$ISOLATION_ID
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
     expose:
       - 4004
     command: settings-tp -C tcp://validator-3:4004


### PR DESCRIPTION
Instead of building debs manually or depending on published docker
images, the test now builds a docker image with the necessary Sawtooth
components installed from the nigthly debs.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>