### PR TITLE
Add syslogging capability to Sawtooth Raft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ raft = "0.3.0"
 sawtooth_sdk = { git = "https://github.com/hyperledger/sawtooth-core.git" }
 serde_json = "1"
 simple_logger = "0.5"
+
+[patch.crates-io]
+log4rs = { git = "https://github.com/ltseeley/log4rs", branch = "config-loading" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Hyperledger Sawtooth Raft consensus engine"
 
 [package.metadata.deb]
 maintainer = "sawtooth"
-depends = "$auto"
+depends = "$auto,rsyslog"
 assets = [
     ["packaging/systemd/sawtooth-raft.service", "/lib/systemd/system/sawtooth-raft.service", "644"],
     ["packaging/systemd/sawtooth-raft", "/etc/default/sawtooth-raft", "644"],
@@ -18,11 +18,12 @@ maintainer-scripts = "packaging/ubuntu"
 clap = "2"
 hex = "0.3"
 log = "0.4"
+log4rs = "0.8"
+log4rs-syslog = "3.0"
 protobuf = "2"
 raft = "0.3.0"
 sawtooth_sdk = { git = "https://github.com/hyperledger/sawtooth-core.git" }
 serde_json = "1"
-simple_logger = "0.5"
 
 [patch.crates-io]
 log4rs = { git = "https://github.com/ltseeley/log4rs", branch = "config-loading" }

--- a/logging/syslog.yaml
+++ b/logging/syslog.yaml
@@ -1,0 +1,9 @@
+appenders:
+  syslog:
+    kind: libc-syslog
+    encoder:
+      pattern: "{h({l:5.5})} | {({M}:{L}):20.20} | {m}{n}"
+root:
+  level: warn
+  appenders:
+    - syslog


### PR DESCRIPTION
Adds the option to log Raft output to syslog by passing the
`logging/syslog.yaml` file to `sawtooth-raft` using the `--log_config` command
line argument. This will enable better debugging when running Raft in a
LR context.

This PR also changes `Cargo.toml` to pull the log4rs crate from `https://github.com/ltseeley/log4rs/tree/config-loading`. The changes made on that branch allow for the logging level to be set after loading the logger configuration from a file.

Signed-off-by: Logan Seeley <seeley@bitwise.io>