### PR TITLE
Update postinst to create `var/lib/sawtooth-raft`

### DIFF
--- a/packaging/ubuntu/postinst
+++ b/packaging/ubuntu/postinst
@@ -17,6 +17,10 @@
 
 set -e
 
+directories="
+    /var/lib/sawtooth-raft
+"
+
 user="sawtooth"
 group="sawtooth"
 
@@ -27,3 +31,10 @@ fi
 if ! getent passwd $user > /dev/null; then
     adduser --quiet --system --ingroup $group $user
 fi
+
+for dir in $directories
+do
+    mkdir -p $dir
+    chown -R $user:$group $dir
+    chmod 750 $dir
+done


### PR DESCRIPTION
Creates the directory that is used by raft to store its state.

Signed-off-by: Logan Seeley <seeley@bitwise.io>