### PR TITLE
Fix out-of-order committing of blocks

### DIFF
--- a/src/block_queue.rs
+++ b/src/block_queue.rs
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::collections::{HashMap, VecDeque};
+
+ use sawtooth_sdk::consensus::{
+     engine::{Block, BlockId},
+ };
+
+struct BlockStatus {
+    // Block received in BlockNew message
+    block: Option<Block>,
+    // Block has been validated
+    block_valid: bool,
+}
+
+impl BlockStatus {
+    fn with_block(block: Block) -> Self {
+        BlockStatus {
+            block: Some(block),
+            block_valid: false,
+        }
+    }
+
+    fn with_valid() -> Self {
+        BlockStatus {
+            block: None,
+            block_valid: true,
+        }
+    }
+}
+
+pub struct BlockQueue {
+    // Backlog of blocks that are being/have been processed by the validator
+    validator_backlog: HashMap<BlockId, BlockStatus>,
+    // Queue of blocks that can be committed when they have been validated
+    commit_queue: VecDeque<BlockId>,
+}
+
+impl BlockQueue {
+    pub fn new() -> Self {
+        BlockQueue {
+            validator_backlog: HashMap::new(),
+            commit_queue: VecDeque::new(),
+        }
+    }
+
+    // Save the block; called when the BlockNew message is received by the engine
+    pub fn block_new(&mut self, block: Block) {
+        let block_id = block.block_id.clone();
+        self.validator_backlog.entry(block_id).and_modify(|status| {
+            status.block = Some(block.clone());
+        }).or_insert_with(|| BlockStatus::with_block(block));
+    }
+
+    // Mark the block as validated; called when the BlockValid message is received by the engine
+    pub fn block_valid(&mut self, block_id: &BlockId) {
+        self.validator_backlog.entry(block_id.clone()).and_modify(|status| {
+            status.block_valid = true;
+        }).or_insert_with(BlockStatus::with_valid);
+    }
+
+    // Mark the block for commit; called when the engine wants to commit the block
+    pub fn add_block_commit(&mut self, block_id: BlockId) {
+        self.commit_queue.push_back(block_id);
+    }
+
+    // Returns the BlockId of the next block that can be committed (if there is one)
+    pub fn get_next_committable(&mut self, chain_head: &Block) -> Option<BlockId> {
+        self.commit_queue.pop_front().filter(|block_id| {
+            if let Some(status) = self.validator_backlog.get(block_id) {
+                if let Some(block) = status.block.clone() {
+                    if status.block_valid && block.previous_id == chain_head.block_id {
+                        // Block is ready
+                        return true;
+                    }
+                }
+            }
+            // Block is not ready, put it back
+            self.commit_queue.push_front(block_id.clone());
+            false
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ use std::process;
 
 use sawtooth_sdk::consensus::zmq_driver::ZmqDriver;
 
+mod block_queue;
 mod cached_storage;
 mod config;
 mod engine;


### PR DESCRIPTION
Modifies the block backlogs to guarantee that a block will only be
committed when the previous block is the chain head.

Signed-off-by: Logan Seeley <seeley@bitwise.io>