### PR TITLE
Bump Raft version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 log4rs = "0.8"
 log4rs-syslog = "3.0"
 protobuf = "2"
-raft = "0.3.0"
+raft = "0.3.1"
 sawtooth_sdk = { git = "https://github.com/hyperledger/sawtooth-core.git" }
 serde_json = "1"
 


### PR DESCRIPTION
v0.3.1 updates the default values of the Config used by Raft to valid values.
v0.3.0 panics because we removed setting these default values.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>