### PR TITLE
Remove version switcher dropdown

### DIFF
--- a/docs/source/_templates/indexcontent.html
+++ b/docs/source/_templates/indexcontent.html
@@ -9,8 +9,6 @@
 
   <h1>Hyperledger Sawtooth Raft Documentation</h1>
 
-  <p><select id="version_switcher"></select></p>
-
   <p class="biglink"><a class="biglink" href="{{ pathto("introduction") }}">{% trans %}Introduction{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}learn about Hyperledger Sawtooth{% endtrans %}</span></p>
 
@@ -19,7 +17,5 @@
 
   <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{% trans %}Table of Contents{% endtrans %}</a><br/>
     <span class="linkdescr">{% trans %}view the detailed list of documentation sections{% endtrans %}</span></p>
-
-<script src="_static/version_switcher.js">
 
 {% endblock %}


### PR DESCRIPTION
This links to the Sawtooth Core docs and should be disabled until a strategy
for providing version switching for multiple repos is implemented.

Signed-off-by: Adam Ludvik <ludvik@bitwise.io>