### PR TITLE
Reduce FsStorage reads from disk, improve tests, and fix bugs

### DIFF
--- a/adhoc/node.yaml
+++ b/adhoc/node.yaml
@@ -40,7 +40,7 @@ services:
       fi && \
       echo \\\"-- /var/lib/sawtooth\\\" && ls /var/lib/sawtooth && \
       echo \\\"-- /shared_data/validators \\\" && ls /shared_data/validators && \
-      if [ ${GENESIS:-0} != 0 ]; then \
+      if [ ${GENESIS:-0} != 0 -a ! -e /shared_data/genesis.batch ]; then \
         echo \\\"Running Genesis\\\" && \
         sawset genesis \
           -k /shared_data/keys/settings.priv \
@@ -52,6 +52,7 @@ services:
           -o config.batch && \
         sawadm genesis \
           config-genesis.batch config.batch && \
+        cp /var/lib/sawtooth/genesis.batch /shared_data/genesis.batch && \
         ls /var/lib/sawtooth; \
       fi && \
       export PEERS=$$(for host in $$(ls /shared_data/validators -1); do \

--- a/src/cached_storage.rs
+++ b/src/cached_storage.rs
@@ -77,7 +77,7 @@ impl Cache {
     }
 
     fn compact(&mut self, compact_index: u64) {
-        self.entries.retain(|entry| entry.index >= compact_index);
+        self.entries.retain(|entry| entry.index > compact_index);
     }
 
     fn append(&mut self, entries: &[Entry]) {

--- a/src/cached_storage.rs
+++ b/src/cached_storage.rs
@@ -171,8 +171,8 @@ impl<S: StorageExt> StorageExt for CachedStorage<S> {
         })
     }
 
-    fn describe() -> &'static str {
-        "file-system backed persistent storage with in-memory cache"
+    fn describe() -> String {
+        format!("cached storage: {}", S::describe())
     }
 }
 

--- a/src/cached_storage.rs
+++ b/src/cached_storage.rs
@@ -244,13 +244,13 @@ mod tests {
         }
 
         // Write entries 1-3
-        let entries = populate_storage(&storage, (0..4).collect());
+        let entries = populate_storage(&storage, (1..4).collect());
 
         // Verify we get the entries we wrote
-        for i in 0..4 {
+        for i in 1..4 {
             for j in i..4 {
                 assert_eq!(
-                    Ok(entries[i..j].to_vec()),
+                    Ok(entries[i-1..j-1].to_vec()),
                     storage.entries(i as u64, j as u64, MAX)
                 );
             }
@@ -265,7 +265,7 @@ mod tests {
         assert_eq!(Ok(0), storage.term(0));
 
         // Write some entries
-        let entries = populate_storage(&storage, (0..6).collect());
+        let entries = populate_storage(&storage, (1..6).collect());
 
         // Assert we get the right terms
         for entry in entries {
@@ -280,8 +280,12 @@ mod tests {
             Err(raft::Error::Store(raft::StorageError::Compacted)),
             storage.term(1)
         );
-        assert_eq!(Ok(2), storage.term(2));
+        assert_eq!(
+            Err(raft::Error::Store(raft::StorageError::Compacted)),
+            storage.term(2)
+        );
         assert_eq!(Ok(3), storage.term(3));
+        assert_eq!(Ok(4), storage.term(4));
     }
 
     #[test]
@@ -293,14 +297,14 @@ mod tests {
         assert_eq!(Ok(1), storage.first_index());
         assert_eq!(Ok(0), storage.last_index());
 
-        populate_storage(&storage, (0..6).collect());
+        populate_storage(&storage, (1..6).collect());
 
-        assert_eq!(Ok(0), storage.first_index());
+        assert_eq!(Ok(1), storage.first_index());
         assert_eq!(Ok(5), storage.last_index());
 
         storage.compact(3).unwrap();
 
-        assert_eq!(Ok(3), storage.first_index());
+        assert_eq!(Ok(4), storage.first_index());
         assert_eq!(Ok(5), storage.last_index());
     }
 
@@ -316,7 +320,7 @@ mod tests {
             storage.compact(0)
         );
 
-        let entries = populate_storage(&storage, (0..10).collect());
+        let entries = populate_storage(&storage, (1..11).collect());
 
         assert_eq!(
             Err(raft::Error::Store(raft::StorageError::Compacted)),
@@ -326,16 +330,16 @@ mod tests {
         assert_eq!(Ok(()), storage.compact(2));
         assert_eq!(
             Err(raft::Error::Store(raft::StorageError::Compacted)),
-            storage.entries(1, 2, MAX)
+            storage.entries(1, 3, MAX)
         );
-        assert_eq!(Ok(entries[2..10].to_vec()), storage.entries(2, 10, MAX));
+        assert_eq!(Ok(entries[2..9].to_vec()), storage.entries(3, 10, MAX));
 
         assert_eq!(Ok(()), storage.compact(4));
         assert_eq!(
             Err(raft::Error::Store(raft::StorageError::Compacted)),
-            storage.entries(2, 4, MAX)
+            storage.entries(2, 5, MAX)
         );
-        assert_eq!(Ok(entries[4..10].to_vec()), storage.entries(4, 10, MAX));
+        assert_eq!(Ok(entries[4..9].to_vec()), storage.entries(5, 10, MAX));
     }
 
     // Test that both implementations of StorageExt produce the same results
@@ -356,8 +360,8 @@ mod tests {
             );
         }
 
-        populate_storage(&mem_storage, (0..6).collect());
-        populate_storage(&cached_storage, (0..6).collect());
+        populate_storage(&mem_storage, (1..6).collect());
+        populate_storage(&cached_storage, (1..6).collect());
 
         // NOTE: This starts at i=1 because I believe the implementation of MemStorage does the
         // wrong thing for (0, 0)

--- a/src/cached_storage.rs
+++ b/src/cached_storage.rs
@@ -363,6 +363,9 @@ mod tests {
         populate_storage(&mem_storage, (1..6).collect());
         populate_storage(&cached_storage, (1..6).collect());
 
+        assert_eq!(mem_storage.first_index(), cached_storage.first_index());
+        assert_eq!(mem_storage.last_index(), cached_storage.last_index());
+
         // NOTE: This starts at i=1 because I believe the implementation of MemStorage does the
         // wrong thing for (0, 0)
         for i in 1..6 {
@@ -392,6 +395,9 @@ mod tests {
 
         for i in 2..5 {
             assert_eq!(mem_storage.compact(i), cached_storage.compact(i));
+
+            assert_eq!(mem_storage.first_index(), cached_storage.first_index());
+            assert_eq!(mem_storage.last_index(), cached_storage.last_index());
         }
 
         assert_eq!(mem_storage.snapshot(), cached_storage.snapshot());

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,7 +50,7 @@ impl<S: StorageExt> RaftEngineConfig<S> {
     }
 }
 
-fn create_storage() -> CachedStorage<impl StorageExt> {
+fn create_storage() -> impl StorageExt {
     CachedStorage::new(
         FsStorage::with_data_dir(get_path_config().data_dir).expect("Failed to create FsStorage")
     )

--- a/src/fs_storage.rs
+++ b/src/fs_storage.rs
@@ -573,6 +573,9 @@ mod tests {
         populate_storage(&mem_storage, (1..6).collect());
         populate_storage(&fs_storage, (1..6).collect());
 
+        assert_eq!(mem_storage.first_index(), fs_storage.first_index());
+        assert_eq!(mem_storage.last_index(), fs_storage.last_index());
+
         // NOTE: This starts at i=1 because I believe the implementation of MemStorage does the
         // wrong thing for (0, 0)
         for i in 1..6 {
@@ -595,6 +598,9 @@ mod tests {
 
         for i in 2..5 {
             assert_eq!(mem_storage.compact(i), fs_storage.compact(i));
+
+            assert_eq!(mem_storage.first_index(), fs_storage.first_index());
+            assert_eq!(mem_storage.last_index(), fs_storage.last_index());
         }
 
         assert_eq!(mem_storage.snapshot(), fs_storage.snapshot());

--- a/src/fs_storage.rs
+++ b/src/fs_storage.rs
@@ -192,7 +192,7 @@ impl StorageExt for FsStorage {
         )?;
 
         if let Some(last) = delete.last() {
-            write_compacted_term(&self.data_dir, last.index)?;
+            write_compacted_term(&self.data_dir, last.get_term())?;
             write_first_index(&self.data_dir, last.get_index() + 1)?;
         }
 

--- a/src/fs_storage.rs
+++ b/src/fs_storage.rs
@@ -196,8 +196,8 @@ impl StorageExt for FsStorage {
         Ok(())
     }
 
-    fn describe() -> &'static str {
-        "file-system backed persistent storage"
+    fn describe() -> String {
+        "file-system backed persistent storage".into()
     }
 }
 

--- a/src/fs_storage.rs
+++ b/src/fs_storage.rs
@@ -176,13 +176,13 @@ impl StorageExt for FsStorage {
             return err_compacted();
         }
 
-        if first_entry_index(&entries) >= compact_index {
+        if first_entry_index(&entries) > compact_index {
             return err_compacted();
         }
 
         let delete: Vec<Entry> = entries
             .into_iter()
-            .take_while(|entry| entry.index < compact_index)
+            .take_while(|entry| entry.index <= compact_index)
             .collect();
 
         if let Some(last) = delete.last() {

--- a/src/fs_storage.rs
+++ b/src/fs_storage.rs
@@ -472,13 +472,13 @@ mod tests {
         }
 
         // Write entries 1-3
-        let entries = populate_storage(&storage, (0..4).collect());
+        let entries = populate_storage(&storage, (1..4).collect());
 
         // Verify we get the entries we wrote
-        for i in 0..4 {
+        for i in 1..4 {
             for j in i..4 {
                 assert_eq!(
-                    Ok(entries[i..j].to_vec()),
+                    Ok(entries[i-1..j-1].to_vec()),
                     storage.entries(i as u64, j as u64, MAX)
                 );
             }
@@ -493,7 +493,7 @@ mod tests {
         assert_eq!(Ok(0), storage.term(0));
 
         // Write some entries
-        let entries = populate_storage(&storage, (0..6).collect());
+        let entries = populate_storage(&storage, (1..6).collect());
 
         // Assert we get the right terms
         for entry in entries {
@@ -505,8 +505,9 @@ mod tests {
 
         // Test that we can still get the term of the last compacted entry
         assert_eq!(err_compacted(), storage.term(1));
-        assert_eq!(Ok(2), storage.term(2));
+        assert_eq!(err_compacted(), storage.term(2));
         assert_eq!(Ok(3), storage.term(3));
+        assert_eq!(Ok(4), storage.term(4));
     }
 
     #[test]
@@ -518,14 +519,14 @@ mod tests {
         assert_eq!(Ok(1), storage.first_index());
         assert_eq!(Ok(0), storage.last_index());
 
-        populate_storage(&storage, (0..6).collect());
+        populate_storage(&storage, (1..6).collect());
 
-        assert_eq!(Ok(0), storage.first_index());
+        assert_eq!(Ok(1), storage.first_index());
         assert_eq!(Ok(5), storage.last_index());
 
         storage.compact(3).unwrap();
 
-        assert_eq!(Ok(3), storage.first_index());
+        assert_eq!(Ok(4), storage.first_index());
         assert_eq!(Ok(5), storage.last_index());
     }
 
@@ -539,17 +540,17 @@ mod tests {
         // Assert that compacting fails when there is nothing to compact
         assert_eq!(err_compacted(), storage.compact(0));
 
-        let entries = populate_storage(&storage, (0..10).collect());
+        let entries = populate_storage(&storage, (1..11).collect());
 
         assert_eq!(err_compacted(), storage.compact(0));
 
         assert_eq!(Ok(()), storage.compact(2));
-        assert_eq!(err_compacted(), storage.entries(1, 2, MAX));
-        assert_eq!(Ok(entries[2..10].to_vec()), storage.entries(2, 10, MAX));
+        assert_eq!(err_compacted(), storage.entries(1, 3, MAX));
+        assert_eq!(Ok(entries[2..9].to_vec()), storage.entries(3, 10, MAX));
 
         assert_eq!(Ok(()), storage.compact(4));
-        assert_eq!(err_compacted(), storage.entries(2, 4, MAX));
-        assert_eq!(Ok(entries[4..10].to_vec()), storage.entries(4, 10, MAX));
+        assert_eq!(err_compacted(), storage.entries(2, 5, MAX));
+        assert_eq!(Ok(entries[4..9].to_vec()), storage.entries(5, 10, MAX));
     }
 
     // Test that both implementations of StorageExt produce the same results
@@ -569,8 +570,8 @@ mod tests {
             assert_eq!(mem_storage.entries(0, i, MAX), fs_storage.entries(0, i, MAX));
         }
 
-        populate_storage(&mem_storage, (0..6).collect());
-        populate_storage(&fs_storage, (0..6).collect());
+        populate_storage(&mem_storage, (1..6).collect());
+        populate_storage(&fs_storage, (1..6).collect());
 
         // NOTE: This starts at i=1 because I believe the implementation of MemStorage does the
         // wrong thing for (0, 0)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -42,7 +42,7 @@ pub trait StorageExt: Storage {
     /// Append the new entries to storage
     fn append(&self, ents: &[Entry]) -> Result<(), Error>;
 
-    fn describe() -> &'static str;
+    fn describe() -> String;
 }
 
 impl StorageExt for MemStorage {
@@ -72,7 +72,7 @@ impl StorageExt for MemStorage {
         self.wl().append(ents)
     }
 
-    fn describe() -> &'static str {
-        "in-memory storage"
+    fn describe() -> String {
+        "in-memory storage".into()
     }
 }


### PR DESCRIPTION
This PR does a lot including:
- Eliminating the "read everything always" behavior of FsStorage
- Fixes some bugs
- Improves parity of FsStorage and CachedStorage with MemStorage
- Fixes up some non-ergonomic code