### PR TITLE
Add applied state

### DIFF
--- a/src/cached_storage.rs
+++ b/src/cached_storage.rs
@@ -251,6 +251,15 @@ impl<S: StorageExt> StorageExt for CachedStorage<S> {
         self.storage.append(entries)
     }
 
+    // This is only read once (on startup), so it does not need to be cached
+    fn applied(&self) -> Result<u64, raft::Error> {
+        self.storage.applied()
+    }
+
+    fn set_applied(&self, applied: u64) -> Result<(), raft::Error> {
+        self.storage.set_applied(applied)
+    }
+
     fn describe() -> String {
         format!("cached storage: {}", S::describe())
     }
@@ -303,6 +312,12 @@ mod tests {
     fn test_storage_ext_compact() {
         let (_tmp, storage) = create_temp_storage("test_storage_ext_compact");
         tests::test_storage_ext_compact(storage);
+    }
+
+    #[test]
+    fn test_applied() {
+        let (_tmp, storage) = create_temp_storage("test_applied");
+        tests::test_applied(storage);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,7 @@ impl<S: StorageExt> RaftEngineConfig<S> {
     fn new(storage: S) -> Self {
         let mut raft = RaftConfig::default();
         raft.max_size_per_msg = 1024 * 1024 * 1024;
+        raft.applied = storage.applied().expect("Applied should have a value");
 
         RaftEngineConfig {
             peers: Vec::new(),
@@ -60,11 +61,12 @@ impl<S: StorageExt> fmt::Debug for RaftEngineConfig<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "RaftEngineConfig {{ peers: {:?}, period: {:?}, raft: {{ election_tick: {}, heartbeat_tick: {} }}, storage: {} }}",
+            "RaftEngineConfig {{ peers: {:?}, period: {:?}, raft: {{ election_tick: {}, heartbeat_tick: {}, applied: {} }}, storage: {} }}",
             self.peers,
             self.period,
             self.raft.election_tick,
             self.raft.heartbeat_tick,
+            self.raft.applied,
             S::describe(),
         )
     }


### PR DESCRIPTION
Update that saves the last applied entry (the entry that corresponds to the last block that was committed) to stable storage whenever a block is committed and loads the last applied entry when Raft starts. This is used to inform the Raft library of which entries it needs to send to the engine when a node restarts (https://docs.rs/raft/0.3.1/raft/struct.Config.html#structfield.applied).