### PR TITLE
Shutdown raft when removed from network

### DIFF
--- a/src/engine.rs
+++ b/src/engine.rs
@@ -30,7 +30,7 @@ use sawtooth_sdk::consensus::{
 
 use config::{self, RaftEngineConfig};
 use ticker;
-use node::SawtoothRaftNode;
+use node::{ReadyStatus, SawtoothRaftNode};
 use storage::StorageExt;
 
 
@@ -110,7 +110,9 @@ impl Engine for RaftEngine {
                 node.tick();
             });
 
-            node.process_ready();
+            if let ReadyStatus::Shutdown = node.process_ready() {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Shuts down the raft process when that raft node is removed from the
network by checking configuration changes to see if a node is being
removed and if the raft_id matches its own.

Signed-off-by: Logan Seeley <seeley@bitwise.io>