### PR TITLE
Replace deprecated crate tempdir with tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ uluru = "0.2"
 log4rs = { git = "https://github.com/ltseeley/log4rs", branch = "config-loading" }
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3.0.4"

--- a/NOTICES
+++ b/NOTICES
@@ -11,7 +11,7 @@ These components are released under separate copyright notices and license terms
 => libc for Rust
 => log for Rust
 => pingcap raft-rs
-=> rust-lang tempdir
+=> rust-lang tempfile
 => rust hex
 => log4rs
 

--- a/src/cached_storage.rs
+++ b/src/cached_storage.rs
@@ -270,13 +270,14 @@ impl<S: StorageExt> StorageExt for CachedStorage<S> {
 mod tests {
     use super::*;
 
-    use tempdir::TempDir;
+    use tempfile::TempDir;
+    use tempfile::Builder;
 
     use fs_storage::FsStorage;
     use storage::tests;
 
     fn create_temp_storage(name: &str) -> (TempDir, CachedStorage<FsStorage>) {
-        let tmp = TempDir::new(name).unwrap();
+        let tmp = Builder::new().prefix(name).tempdir().unwrap();
         let storage = CachedStorage::new(
             FsStorage::with_data_dir(tmp.path().into()).expect("Failed to create FsStorage")
         );

--- a/src/fs_storage.rs
+++ b/src/fs_storage.rs
@@ -428,12 +428,13 @@ fn u64_from_bytes(bytes: [u8; mem::size_of::<u64>()]) -> u64 {
 mod tests {
     use super::*;
 
-    use tempdir::TempDir;
+    use tempfile::TempDir;
+    use tempfile::Builder;
 
     use storage::tests;
 
     fn create_temp_storage(name: &str) -> (TempDir, FsStorage) {
-        let tmp = TempDir::new(name).unwrap();
+        let tmp = Builder::new().prefix(name).tempdir().unwrap();
         let storage = FsStorage::with_data_dir(tmp.path().into()).unwrap();
         (tmp, storage)
     }
@@ -441,7 +442,7 @@ mod tests {
     // Test that read and write functions work
     #[test]
     fn test_rw() {
-        let tmp = TempDir::new("test_rw").unwrap();
+        let tmp = Builder::new().prefix("test_rw").tempdir().unwrap();
 
         // Write to file
         assert_eq!((), write_hard_state(tmp.path(), &HardState::default()).unwrap());

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ extern crate serde_json;
 extern crate uluru;
 
 #[cfg(test)]
-extern crate tempdir;
+extern crate tempfile;
 
 use log4rs::append::console::ConsoleAppender;
 use log4rs::config::{Appender, Config, Root};


### PR DESCRIPTION
Replaced references and usage of the deprecated tempdir crate
with tempfile crate

Signed-off-by: askmish <ashish.k.mishra@intel.com>