### PR TITLE
Update consensus configuration settings in adhoc

### DIFF
--- a/adhoc/node.yaml
+++ b/adhoc/node.yaml
@@ -49,7 +49,8 @@ services:
           -o config-genesis.batch && \
         sawset proposal create \
           -k /shared_data/keys/settings.priv \
-          sawtooth.consensus.algorithm=raft \
+          sawtooth.consensus.algorithm.name=sawtooth-raft-engine \
+          sawtooth.consensus.algorithm.version=0.1.0 \
           sawtooth.consensus.raft.peers=\\['\\\"'$$(cd /shared_data/validators && paste $$(ls -1) -d , | sed s/,/\\\\\\\",\\\\\\\"/g)'\\\"'\\]
           -o config.batch && \
         sawadm genesis \


### PR DESCRIPTION
Updates the settings for the consensus algorithm name and version in
`adhoc/node.yaml` to the required values.

Signed-off-by: Logan Seeley <seeley@bitwise.io>