### PR TITLE
Add compose files for grafana statistics

### DIFF
--- a/adhoc/workload.yaml
+++ b/adhoc/workload.yaml
@@ -42,6 +42,7 @@ services:
         --key-file /shared_data/keys/workload.priv \
         --rate ${RATE:-1} \
         --urls $$TARGETS \
+        --batch-size ${BATCH:-1} \
     \""
     volumes:
       - raft_shared_data:/shared_data

--- a/tests/grafana.yaml
+++ b/tests/grafana.yaml
@@ -1,0 +1,64 @@
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "3.6"
+
+networks:
+  rest_apis:
+    external:
+      name: raft_rest_apis
+  validators:
+    external:
+      name: raft_validators
+
+services:
+
+  influxdb:
+    build:
+      context: $SAWTOOTH_CORE/docker
+      dockerfile: influxdb/sawtooth-stats-influxdb
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-stats-influxdb:latest
+    ports:
+      - "8086:8086"
+    networks:
+      default:
+      rest_apis:
+      validators:
+    stop_signal: SIGKILL
+
+  grafana:
+    build:
+      context: $SAWTOOTH_CORE/docker
+      dockerfile: grafana/sawtooth-stats-grafana
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    image: sawtooth-stats-grafana:latest
+    ports:
+      - "3000:3000"
+    networks:
+      default:
+      rest_apis:
+      validators:
+    volumes:
+      - $SAWTOOTH_CORE:/project/sawtooth-core
+    depends_on:
+      - influxdb
+    stop_signal: SIGKILL

--- a/tests/node-with-stats.yaml
+++ b/tests/node-with-stats.yaml
@@ -1,0 +1,156 @@
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+version: "3.6"
+
+# Validators across all compose files join this docker network for inter-node
+# communication
+networks:
+  validators:
+    external:
+      name: raft_validators
+  rest_apis:
+    external:
+      name: raft_rest_apis
+
+volumes:
+  raft_shared_data:
+    external: true
+
+services:
+
+  validator:
+    build:
+      context: .
+      dockerfile: sawtooth-raft-test.dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    labels:
+      - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+    command: "bash -c \"\
+      cp /telegraf/telegraf.conf /etc/telegraf/telegraf.conf && \
+      (telegraf &) && \
+      if [ ! -e /etc/sawtooth/keys/validator.pub ]; then sawadm keygen; fi && \
+      if [ ! -e /shared_data/validators/$$(hostname) ]; then \
+        cat /etc/sawtooth/keys/validator.pub > /shared_data/validators/$$(hostname); \
+      fi && \
+      echo \\\"-- /var/lib/sawtooth\\\" && ls /var/lib/sawtooth && \
+      echo \\\"-- /shared_data/validators \\\" && ls /shared_data/validators && \
+      if [ ${GENESIS:-0} != 0 -a ! -e /shared_data/genesis.batch ]; then \
+        echo \\\"Running Genesis\\\" && \
+        sawset genesis \
+          -k /shared_data/keys/settings.priv \
+          -o config-genesis.batch && \
+        sawset proposal create \
+          -k /shared_data/keys/settings.priv \
+          sawtooth.consensus.algorithm.name=sawtooth-raft-engine \
+          sawtooth.consensus.algorithm.version=0.1.0 \
+          sawtooth.consensus.raft.peers=\\['\\\"'$$(cd /shared_data/validators && paste $$(ls -1) -d , | sed s/,/\\\\\\\",\\\\\\\"/g)'\\\"'\\]
+          -o config.batch && \
+        sawadm genesis \
+          config-genesis.batch config.batch && \
+        cp /var/lib/sawtooth/genesis.batch /shared_data/genesis.batch && \
+        ls /var/lib/sawtooth; \
+      fi && \
+      export PEERS=$$(for host in $$(ls /shared_data/validators -1); do \
+            if [ $$host != $$(hostname) ]; then \
+              echo \\\"tcp://$$host:8800\\\"; \
+            fi; done | tr \\\"\n\\\" \\\",\\\" | sed s\\/,$$\\/\\\n\\/); \
+      echo \\\"-- PEERS \\\" && echo \\\"PEERS=$$PEERS\\\"; \
+      if [ \\\"$$PEERS\\\" = \\\"\\\" ]; then \
+        echo \\\"No peers to connect to...\\\";
+        sawtooth-validator -vv \
+            --endpoint tcp://$$(hostname):8800 \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth1:8800 \
+            --bind consensus:tcp://eth0:5050 \
+            --peering static \
+            --scheduler parallel \
+            --opentsdb-url http://influxdb:8086 \
+            --opentsdb-db metrics; \
+      else \
+        echo \\\"Connecting to $$PEERS\\\";
+        sawtooth-validator -vv \
+            --endpoint tcp://$$(hostname):8800 \
+            --bind component:tcp://eth0:4004 \
+            --bind network:tcp://eth1:8800 \
+            --bind consensus:tcp://eth0:5050 \
+            --peering static \
+            --peers $$PEERS \
+            --scheduler parallel \
+            --opentsdb-url http://influxdb:8086 \
+            --opentsdb-db metrics; \
+      fi \
+    \""
+    volumes:
+      - raft_shared_data:/shared_data
+      - $SAWTOOTH_CORE/docker:/telegraf
+    networks:
+      default:
+      validators:
+    expose:
+      - 8800
+    stop_signal: SIGKILL
+
+  raft:
+    image: sawtooth-raft-engine-local
+    labels:
+      - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+    build:
+      context: .
+      dockerfile: ../Dockerfile
+      args:
+        - http_proxy
+        - https_proxy
+        - no_proxy
+    volumes:
+      - ${SAWOOTH_RAFT:-..}:/project/sawtooth-raft
+    working_dir: /project/sawtooth-raft/
+    command: ./target/debug/raft-engine --connect tcp://validator:5050 -v
+
+  rest-api:
+    image: hyperledger/sawtooth-rest-api:nightly
+    labels:
+      - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+    command: "bash -c \"
+      if [ ! -e /shared_data/rest_apis/$$(hostname) ]; then \
+        touch /shared_data/rest_apis/$$(hostname);
+      fi && \
+      sawtooth-rest-api --connect tcp://validator:4004 --bind $$(hostname):8008 --opentsdb-url http://influxdb:8086 --opentsdb-db metrics; \
+    \""
+    volumes:
+      - raft_shared_data:/shared_data
+    networks:
+      default:
+      rest_apis:
+    expose:
+      - 8008
+    stop_signal: SIGKILL
+
+  intkey-tp-python:
+    image: hyperledger/sawtooth-intkey-tp-python:nightly
+    labels:
+      - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+    command: intkey-tp-python -vv -C tcp://validator:4004
+    stop_signal: SIGKILL
+
+  settings-tp:
+    image: hyperledger/sawtooth-settings-tp:nightly
+    labels:
+      - "com.sawtooth.isolation_id=${ISOLATION_ID:-}"
+    command: settings-tp -C tcp://validator:4004 -v
+    stop_signal: SIGKILL

--- a/tests/sawtooth-raft-test.dockerfile
+++ b/tests/sawtooth-raft-test.dockerfile
@@ -55,3 +55,10 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/nightly bionic univers
  && chmod +x /usr/local/bin/docker-compose \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sL https://repos.influxdata.com/influxdb.key | apt-key add -
+RUN echo deb https://repos.influxdata.com/ubuntu bionic stable > /etc/apt/sources.list.d/influxdb.list
+RUN apt-get update && apt-get install -y -q \
+    telegraf \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
There are two commits in this PR, one with newly introduced compose files for grafana. Another is providing option to limit number of transactions in a batch while sending workload.
1. Introduce a new compose file similar to adhoc/node.yaml under
tests, which enables telegraf statistics to be sent to influxdb.
2. Introduce a compose file to start grafana and influxdb services
which can be used to send statistics from sawtooth-raft adhoc
tests.

There's planned activity to update document, so not included with this PR.