### PR TITLE
Update Raft to use Sawtooth Rust SDK 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ log4rs = "0.8"
 log4rs-syslog = "3.0"
 protobuf = "2"
 raft = "0.3.1"
-sawtooth-sdk = { git = "https://github.com/hyperledger/sawtooth-sdk-rust.git" }
+sawtooth-sdk = "0.2"
 serde_json = "1"
 uluru = "0.2"
 


### PR DESCRIPTION
Signed-off-by: Andrea Gunderson <agunde@bitwise.io>