### PR TITLE
Enable lint checks on sawtooth-raft

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,12 +33,14 @@ RUN curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/proto
  && unzip protoc-3.5.1-linux-x86_64.zip -d protoc3 \
  && rm protoc-3.5.1-linux-x86_64.zip
 
+ENV PATH=$PATH:/protoc3/bin:/project/sawtooth-raft/bin:/root/.cargo/bin \
+    CARGO_INCREMENTAL=0
+
 RUN curl https://sh.rustup.rs -sSf > /usr/bin/rustup-init \
  && chmod +x /usr/bin/rustup-init \
- && rustup-init -y
-
-ENV PATH=$PATH:/protoc3/bin:/project/sawtooth-core/bin:/root/.cargo/bin \
-    CARGO_INCREMENTAL=0
+ && rustup-init -y \
+ && rustup component add rustfmt \
+ && rustup component add clippy
 
 WORKDIR /project/sawtooth-raft
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,10 +80,19 @@ pipeline {
             }
         }
 
+        stage("Run Lint") {
+            steps {
+                sh 'docker-compose run --rm raft-engine cargo fmt --version'
+                sh 'docker-compose run --rm raft-engine cargo fmt -- --check'
+                sh 'docker-compose run --rm raft-engine cargo clippy --version'
+                sh 'docker-compose run --rm raft-engine cargo clippy --'
+            }
+        }
+
         stage("Build Raft") {
             steps {
-              sh "docker-compose up --build --abort-on-container-exit --force-recreate --renew-anon-volumes --exit-code-from raft-engine"
-              sh "docker-compose -f docker-compose-installed.yaml build"
+                sh "docker-compose up --build --abort-on-container-exit --force-recreate --renew-anon-volumes --exit-code-from raft-engine"
+                sh "docker-compose -f docker-compose-installed.yaml build"
             }
         }
 

--- a/src/block_queue.rs
+++ b/src/block_queue.rs
@@ -17,9 +17,7 @@
 
 use std::collections::{HashMap, VecDeque};
 
- use sawtooth_sdk::consensus::{
-     engine::{Block, BlockId},
- };
+use sawtooth_sdk::consensus::engine::{Block, BlockId};
 
 struct BlockStatus {
     // Block received in BlockNew message
@@ -63,16 +61,22 @@ impl BlockQueue {
     // Save the block; called when the BlockNew message is received by the engine
     pub fn block_new(&mut self, block: Block) {
         let block_id = block.block_id.clone();
-        self.validator_backlog.entry(block_id).and_modify(|status| {
-            status.block = Some(block.clone());
-        }).or_insert_with(|| BlockStatus::with_block(block));
+        self.validator_backlog
+            .entry(block_id)
+            .and_modify(|status| {
+                status.block = Some(block.clone());
+            })
+            .or_insert_with(|| BlockStatus::with_block(block));
     }
 
     // Mark the block as validated; called when the BlockValid message is received by the engine
     pub fn block_valid(&mut self, block_id: &BlockId) {
-        self.validator_backlog.entry(block_id.clone()).and_modify(|status| {
-            status.block_valid = true;
-        }).or_insert_with(BlockStatus::with_valid);
+        self.validator_backlog
+            .entry(block_id.clone())
+            .and_modify(|status| {
+                status.block_valid = true;
+            })
+            .or_insert_with(BlockStatus::with_valid);
     }
 
     // Mark the block for commit; called when the engine wants to commit the block

--- a/src/block_queue.rs
+++ b/src/block_queue.rs
@@ -70,6 +70,7 @@ impl BlockQueue {
     }
 
     // Mark the block as validated; called when the BlockValid message is received by the engine
+    #[allow(clippy::ptr_arg)]
     pub fn block_valid(&mut self, block_id: &BlockId) {
         self.validator_backlog
             .entry(block_id.clone())

--- a/src/cached_storage.rs
+++ b/src/cached_storage.rs
@@ -15,13 +15,15 @@
  * ------------------------------------------------------------------------------
  */
 
-use std::ops::Range;
 use std::cell::RefCell;
+use std::ops::Range;
 
-use uluru;
 use raft::{
-    self, eraftpb::{ConfState, Entry, HardState, Snapshot}, RaftState, Storage,
+    self,
+    eraftpb::{ConfState, Entry, HardState, Snapshot},
+    RaftState, Storage,
 };
+use uluru;
 
 use storage::StorageExt;
 
@@ -61,7 +63,9 @@ struct TermCache(uluru::LRUCache<[uluru::Entry<(u64, u64)>; CACHE_SIZE]>);
 
 impl TermCache {
     fn get(&mut self, idx: u64) -> Option<u64> {
-        self.0.find(|(index, _term)| *index == idx).map(|(_index, term)| *term)
+        self.0
+            .find(|(index, _term)| *index == idx)
+            .map(|(_index, term)| *term)
     }
 
     fn insert(&mut self, index: u64, term: u64) {
@@ -151,10 +155,8 @@ impl<S: StorageExt> Storage for CachedStorage<S> {
                     }
                     Ok(range)
                 }
-                None => {
-                    self.storage.entries(low, high, max_size)
-                }
-            }
+                None => self.storage.entries(low, high, max_size),
+            };
         }
 
         match self.storage.entries(low, high, max_size) {
@@ -199,7 +201,6 @@ impl<S: StorageExt> Storage for CachedStorage<S> {
         if let Some(ref last_index) = cache.last_index {
             return Ok(*last_index);
         }
-
 
         self.storage.last_index().map(|last_index| {
             cache.last_index = Some(last_index);
@@ -265,13 +266,12 @@ impl<S: StorageExt> StorageExt for CachedStorage<S> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use tempfile::TempDir;
     use tempfile::Builder;
+    use tempfile::TempDir;
 
     use fs_storage::FsStorage;
     use storage::tests;
@@ -279,7 +279,7 @@ mod tests {
     fn create_temp_storage(name: &str) -> (TempDir, CachedStorage<FsStorage>) {
         let tmp = Builder::new().prefix(name).tempdir().unwrap();
         let storage = CachedStorage::new(
-            FsStorage::with_data_dir(tmp.path().into()).expect("Failed to create FsStorage")
+            FsStorage::with_data_dir(tmp.path().into()).expect("Failed to create FsStorage"),
         );
         (tmp, storage)
     }
@@ -307,7 +307,6 @@ mod tests {
         let (_tmp, storage) = create_temp_storage("test_first_and_last_index");
         tests::test_first_and_last_index(storage);
     }
-
 
     #[test]
     fn test_storage_ext_compact() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,10 @@ use std::time::Duration;
 
 use hex;
 use raft::Config as RaftConfig;
-use sawtooth_sdk::consensus::{engine::{BlockId, PeerId}, service::Service};
+use sawtooth_sdk::consensus::{
+    engine::{BlockId, PeerId},
+    service::Service,
+};
 use serde_json;
 
 use cached_storage::CachedStorage;
@@ -53,7 +56,7 @@ impl<S: StorageExt> RaftEngineConfig<S> {
 
 fn create_storage() -> impl StorageExt {
     CachedStorage::new(
-        FsStorage::with_data_dir(get_path_config().data_dir).expect("Failed to create FsStorage")
+        FsStorage::with_data_dir(get_path_config().data_dir).expect("Failed to create FsStorage"),
     )
 }
 
@@ -78,7 +81,6 @@ pub fn load_raft_config(
     block_id: BlockId,
     service: &mut Box<Service>,
 ) -> RaftEngineConfig<impl StorageExt> {
-
     let mut config = RaftEngineConfig::new(create_storage());
     config.raft.id = peer_id_to_raft_id(peer_id);
     config.raft.tag = format!("[{}]", config.raft.id);
@@ -91,7 +93,10 @@ pub fn load_raft_config(
     ];
 
     let settings: HashMap<String, String> = service
-        .get_settings(block_id, settings_keys.into_iter().map(String::from).collect())
+        .get_settings(
+            block_id,
+            settings_keys.into_iter().map(String::from).collect(),
+        )
         .expect("Failed to get settings keys");
 
     if let Some(heartbeat_tick) = settings.get("sawtooth.consensus.raft.heartbeat_tick") {
@@ -145,7 +150,8 @@ pub fn get_peers_from_settings(settings: &HashMap<String, String>) -> Vec<PeerId
     let peers: Vec<String> = serde_json::from_str(peers_setting_value)
         .expect("Invalid value at 'sawtooth.consensus.raft.peers'");
 
-    peers.into_iter()
+    peers
+        .into_iter()
         .map(|s| PeerId::from(hex::decode(s).expect("Peer id not valid hex")))
         .collect()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,7 +75,7 @@ impl<S: StorageExt> fmt::Debug for RaftEngineConfig<S> {
     }
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(borrowed_box))]
+#[allow(clippy::ptr_arg, clippy::borrowed_box)]
 pub fn load_raft_config(
     peer_id: &PeerId,
     block_id: BlockId,
@@ -131,6 +131,7 @@ pub fn load_raft_config(
 }
 
 /// Create a u64 value from the last eight bytes in the peer id
+#[allow(clippy::ptr_arg)]
 pub fn peer_id_to_raft_id(peer_id: &PeerId) -> u64 {
     let bytes: &[u8] = peer_id.as_ref();
     assert!(bytes.len() >= 8);

--- a/src/fs_storage.rs
+++ b/src/fs_storage.rs
@@ -325,7 +325,7 @@ fn read_entries<P: AsRef<Path>>(
 
 // DirEntry mappers
 
-#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
+#[allow(clippy::needless_pass_by_value)]
 fn dir_entry_to_raft_entry(dir_entry: fs::DirEntry) -> io::Result<Entry> {
     read_pb_from_file(dir_entry.path())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,10 +91,12 @@ fn main() {
     let (driver, _stop) = ZmqDriver::new();
 
     info!("Raft Node connecting to '{}'", &args.endpoint);
-    driver.start(&args.endpoint, raft_engine).unwrap_or_else(|err| {
-        error!("{}", err);
-        process::exit(1);
-    });
+    driver
+        .start(&args.endpoint, raft_engine)
+        .unwrap_or_else(|err| {
+            error!("{}", err);
+            process::exit(1);
+        });
 }
 
 fn get_console_config(log_level: log::LevelFilter) -> Config {
@@ -123,7 +125,7 @@ fn parse_args() -> RaftCliArgs {
          "increase output verbosity")
         (@arg logconfig: -L --log_config +takes_value
          "path to logging config file"))
-        .get_matches();
+    .get_matches();
 
     let log_level = match matches.occurrences_of("verbose") {
         0 => log::LevelFilter::Warn,

--- a/src/node.rs
+++ b/src/node.rs
@@ -131,12 +131,13 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
             );
             info!("Leader({:?}) proposed block {:?}", self.peer_id, block_id);
             self.raw_node
-                .propose(vec![], block_id.clone().into())
+                .propose(vec![], block_id.clone())
                 .expect("Failed to propose block to Raft");
             self.leader_state = Some(LeaderState::Proposing(block_id));
         }
     }
 
+    #[allow(clippy::ptr_arg)]
     pub fn on_block_commit(&mut self, block_id: &BlockId) {
         if match self.leader_state {
             Some(LeaderState::Committing(ref committing)) => committing == block_id,
@@ -386,6 +387,7 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
         ReadyStatus::Continue
     }
 
+    #[allow(clippy::ptr_arg)]
     fn commit_block(&mut self, block_id: &BlockId) {
         if match self.leader_state {
             Some(LeaderState::Proposing(ref proposed)) => block_id == proposed,

--- a/src/node.rs
+++ b/src/node.rs
@@ -22,23 +22,18 @@ use std::time::{Duration, Instant};
 use protobuf::{self, Message as ProtobufMessage};
 use raft::{
     self,
-    eraftpb::{
-        ConfChange,
-        ConfChangeType,
-        EntryType,
-        Message as RaftMessage,
-    },
+    eraftpb::{ConfChange, ConfChangeType, EntryType, Message as RaftMessage},
     raw_node::RawNode,
 };
 
 use sawtooth_sdk::consensus::{
-    engine::{Block, BlockId, PeerId, Error},
+    engine::{Block, BlockId, Error, PeerId},
     service::Service,
 };
 
 use block_queue::BlockQueue;
+use config::{get_peers_from_settings, peer_id_to_raft_id};
 use storage::StorageExt;
-use config::{peer_id_to_raft_id, get_peers_from_settings};
 
 /// Possible states a leader node can be in
 ///
@@ -84,7 +79,7 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
         raw_node: RawNode<S>,
         service: Box<Service>,
         peers: Vec<PeerId>,
-        period: Duration
+        period: Duration,
     ) -> Self {
         SawtoothRaftNode {
             peer_id,
@@ -93,26 +88,32 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
             leader_state: None,
             follower_state: Some(FollowerState::Idle),
             block_queue: BlockQueue::new(),
-            raft_id_to_peer_id: peers.into_iter().map(|peer_id| (peer_id_to_raft_id(&peer_id), peer_id)).collect(),
+            raft_id_to_peer_id: peers
+                .into_iter()
+                .map(|peer_id| (peer_id_to_raft_id(&peer_id), peer_id))
+                .collect(),
             period,
         }
     }
 
     pub fn on_block_new(&mut self, block: Block) {
         if match self.leader_state {
-            Some(LeaderState::Publishing(ref block_id)) => {
-                block_id == &block.block_id
-            },
+            Some(LeaderState::Publishing(ref block_id)) => block_id == &block.block_id,
             _ => false,
         } {
-            debug!("Leader({:?}) transition to Validating block {:?}", self.peer_id, block.block_id);
+            debug!(
+                "Leader({:?}) transition to Validating block {:?}",
+                self.peer_id, block.block_id
+            );
             self.leader_state = Some(LeaderState::Validating(block.block_id.clone()));
         }
 
         debug!("Block has been received: {:?}", &block);
         self.block_queue.block_new(block.clone());
 
-        self.service.check_blocks(vec![block.block_id]).expect("Failed to send check blocks");
+        self.service
+            .check_blocks(vec![block.block_id])
+            .expect("Failed to send check blocks");
     }
 
     pub fn on_block_valid(&mut self, block_id: BlockId) {
@@ -120,51 +121,61 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
         debug!("Block has been validated: {:?}", &block_id);
         self.block_queue.block_valid(&block_id);
         if match self.leader_state {
-            Some(LeaderState::Publishing(ref expected)) => {
-                expected == &block_id
-            },
-            Some(LeaderState::Validating(ref expected)) => {
-                expected == &block_id
-            },
+            Some(LeaderState::Publishing(ref expected)) => expected == &block_id,
+            Some(LeaderState::Validating(ref expected)) => expected == &block_id,
             _ => false,
         } {
-            debug!("Leader({:?}) transition to Proposing block {:?}", self.peer_id, block_id);
+            debug!(
+                "Leader({:?}) transition to Proposing block {:?}",
+                self.peer_id, block_id
+            );
             info!("Leader({:?}) proposed block {:?}", self.peer_id, block_id);
-            self.raw_node.propose(vec![], block_id.clone().into()).expect("Failed to propose block to Raft");
+            self.raw_node
+                .propose(vec![], block_id.clone().into())
+                .expect("Failed to propose block to Raft");
             self.leader_state = Some(LeaderState::Proposing(block_id));
         }
     }
 
     pub fn on_block_commit(&mut self, block_id: &BlockId) {
         if match self.leader_state {
-            Some(LeaderState::Committing(ref committing)) => {
-                committing == block_id
-            },
+            Some(LeaderState::Committing(ref committing)) => committing == block_id,
             _ => false,
         } {
             let entry = self.block_queue.block_committed();
-            self.raw_node.raft.mut_store().set_applied(entry).expect("Failed to set last applied entry.");
+            self.raw_node
+                .raft
+                .mut_store()
+                .set_applied(entry)
+                .expect("Failed to set last applied entry.");
 
             if let Some(change) = self.check_for_conf_change(block_id.clone()) {
                 debug!("Leader({:?}) transition to ChangingConfig", self.peer_id);
                 self.leader_state = Some(LeaderState::ChangingConfig);
                 self.raw_node.propose_conf_change(vec![], change).unwrap();
             } else {
-                debug!("Leader({:?}) transition to Building block {:?}", self.peer_id, block_id);
+                debug!(
+                    "Leader({:?}) transition to Building block {:?}",
+                    self.peer_id, block_id
+                );
                 self.leader_state = Some(LeaderState::Building(Instant::now()));
-                self.service.initialize_block(None).expect("Failed to initialize block");
+                self.service
+                    .initialize_block(None)
+                    .expect("Failed to initialize block");
             }
         }
 
         if match self.follower_state {
-            Some(FollowerState::Committing(ref committing)) => {
-                committing == block_id
-            },
+            Some(FollowerState::Committing(ref committing)) => committing == block_id,
             _ => false,
         } {
             info!("Peer({:?}) committed block {:?}", self.peer_id, block_id);
             let entry = self.block_queue.block_committed();
-            self.raw_node.raft.mut_store().set_applied(entry).expect("Failed to set last applied entry.");
+            self.raw_node
+                .raft
+                .mut_store()
+                .set_applied(entry)
+                .expect("Failed to set last applied entry.");
             self.follower_state = Some(FollowerState::Idle);
         }
     }
@@ -173,7 +184,10 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
         let raft_message = protobuf::parse_from_bytes::<RaftMessage>(message)
             .expect("Failed to interpret bytes as Raft message");
         self.raw_node.step(raft_message).unwrap_or_else(|err| {
-            warn!("Peer({:?}) encountered error when stepping: {:?}", self.peer_id, err);
+            warn!(
+                "Peer({:?}) encountered error when stepping: {:?}",
+                self.peer_id, err
+            );
         });
     }
 
@@ -188,43 +202,48 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
         // 2. We are building a block
         // 3. The block has been building long enough
         if match self.leader_state {
-            Some(LeaderState::Building(instant)) => {
-                instant.elapsed() >= self.period
-            }
+            Some(LeaderState::Building(instant)) => instant.elapsed() >= self.period,
             _ => false,
         } {
             match self.service.summarize_block() {
                 //Ignore Ok condition
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(Error::BlockNotReady) => {
-                    debug!("Leader({:?}) tried to summarize block but block not ready", self.peer_id);
+                    debug!(
+                        "Leader({:?}) tried to summarize block but block not ready",
+                        self.peer_id
+                    );
                     return;
-                },
+                }
                 Err(err) => panic!("Failed to summarize block: {:?}", err),
             };
 
             match self.service.finalize_block(vec![]) {
                 Ok(block_id) => {
-                    debug!("Leader({:?}) transition to Publishing block {:?}", self.peer_id, block_id);
+                    debug!(
+                        "Leader({:?}) transition to Publishing block {:?}",
+                        self.peer_id, block_id
+                    );
                     self.leader_state = Some(LeaderState::Publishing(block_id));
-                },
+                }
                 Err(Error::BlockNotReady) => {
-                     // Try again later
-                    debug!("Leader({:?}) tried to finalize block but block not ready", self.peer_id);
-                },
+                    // Try again later
+                    debug!(
+                        "Leader({:?}) tried to finalize block but block not ready",
+                        self.peer_id
+                    );
+                }
                 Err(err) => panic!("Failed to finalize block: {:?}", err),
             };
         }
     }
 
     fn send_msg(&mut self, raft_msg: &RaftMessage) {
-        let msg = raft_msg.write_to_bytes().expect("Could not serialize RaftMessage");
+        let msg = raft_msg
+            .write_to_bytes()
+            .expect("Could not serialize RaftMessage");
         if let Some(peer_id) = self.raft_id_to_peer_id.get(&raft_msg.to) {
-            match self.service.send_to(
-                peer_id,
-                "",
-                msg.to_vec(),
-            ) {
+            match self.service.send_to(peer_id, "", msg.to_vec()) {
                 Ok(_) => (),
                 Err(Error::UnknownPeer(s)) => warn!("Tried to send to disconnected peer: {}", s),
                 Err(err) => panic!("Failed to send to peer: {:?}", err),
@@ -248,34 +267,48 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
             if self.leader_state.is_none() {
                 // Check if we stepped up as leader from follower while in committing state
                 if let Some(FollowerState::Committing(ref block_id)) = self.follower_state {
-                    debug!("Follower({:?}) became leader while it was in committing state",
-                        self.peer_id);
+                    debug!(
+                        "Follower({:?}) became leader while it was in committing state",
+                        self.peer_id
+                    );
                     self.leader_state = Some(LeaderState::Committing(block_id.clone()));
                 } else {
                     // We need to start building a block
-                    debug!("Leader({:?}) became leader, intializing block", self.peer_id);
+                    debug!(
+                        "Leader({:?}) became leader, intializing block",
+                        self.peer_id
+                    );
                     self.leader_state = Some(LeaderState::Building(Instant::now()));
-                    self.service.initialize_block(None).expect("Failed to initialize block");
+                    self.service
+                        .initialize_block(None)
+                        .expect("Failed to initialize block");
                 }
                 self.follower_state = None;
             }
             // If the peer is leader, the leader can send messages to other followers ASAP.
             for msg in ready.messages.drain(..) {
-                debug!("Leader({:?}) wants to send message: {:?}", self.peer_id, msg);
+                debug!(
+                    "Leader({:?}) wants to send message: {:?}",
+                    self.peer_id, msg
+                );
                 self.send_msg(&msg);
             }
         }
 
         if !raft::is_empty_snap(&ready.snapshot) {
             // This is a snapshot, we need to apply the snapshot at first.
-            self.raw_node.mut_store()
+            self.raw_node
+                .mut_store()
                 .apply_snapshot(&ready.snapshot)
                 .unwrap();
         }
 
         if !ready.entries.is_empty() {
             // Append entries to the Raft log
-            self.raw_node.mut_store().append(&ready.entries).expect("Failed to append entries");
+            self.raw_node
+                .mut_store()
+                .append(&ready.entries)
+                .expect("Failed to append entries");
         }
 
         if let Some(ref hs) = ready.hs {
@@ -294,7 +327,7 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
                     }
                     Some(LeaderState::Committing(ref block_id)) => {
                         self.follower_state = Some(FollowerState::Committing(block_id.clone()));
-                    },
+                    }
                     _ => (),
                 }
                 self.leader_state = None;
@@ -320,8 +353,11 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
 
                 if entry.get_entry_type() == EntryType::EntryNormal {
                     let block_id: BlockId = BlockId::from(Vec::from(entry.get_data()));
-                    self.block_queue.add_block_commit(block_id, entry.get_index());
-                } else if entry.get_entry_type() == EntryType::EntryConfChange && entry.get_term() != 1 {
+                    self.block_queue
+                        .add_block_commit(block_id, entry.get_index());
+                } else if entry.get_entry_type() == EntryType::EntryConfChange
+                    && entry.get_term() != 1
+                {
                     let change: ConfChange = protobuf::parse_from_bytes(entry.get_data())
                         .expect("Failed to parse ConfChange");
 
@@ -332,7 +368,9 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
                     if let Some(LeaderState::ChangingConfig) = self.leader_state {
                         debug!("Leader({:?}) transition to Building block", self.peer_id);
                         self.leader_state = Some(LeaderState::Building(Instant::now()));
-                        self.service.initialize_block(None).expect("Failed to initialize block");
+                        self.service
+                            .initialize_block(None)
+                            .expect("Failed to initialize block");
                     }
                 }
             }
@@ -350,33 +388,43 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
 
     fn commit_block(&mut self, block_id: &BlockId) {
         if match self.leader_state {
-            Some(LeaderState::Proposing(ref proposed)) => {
-                block_id == proposed
-            },
+            Some(LeaderState::Proposing(ref proposed)) => block_id == proposed,
             _ => false,
         } {
-            debug!("Leader({:?}) transitioning to Committing block {:?}", self.peer_id, block_id);
+            debug!(
+                "Leader({:?}) transitioning to Committing block {:?}",
+                self.peer_id, block_id
+            );
             self.leader_state = Some(LeaderState::Committing(block_id.clone()));
-            self.service.commit_block(block_id.clone()).expect("Failed to commit block");
+            self.service
+                .commit_block(block_id.clone())
+                .expect("Failed to commit block");
         }
 
         if let Some(FollowerState::Idle) = self.follower_state {
             debug!("Peer({:?}) committing block {:?}", self.peer_id, block_id);
             self.follower_state = Some(FollowerState::Committing(block_id.clone()));
-            self.service.commit_block(block_id.clone()).expect("Failed to commit block");
+            self.service
+                .commit_block(block_id.clone())
+                .expect("Failed to commit block");
         }
     }
 
     fn check_for_conf_change(&mut self, block_id: BlockId) -> Option<ConfChange> {
         // Get list of peers from settings
-        let settings = self.service
-            .get_settings(block_id, vec![String::from("sawtooth.consensus.raft.peers")])
+        let settings = self
+            .service
+            .get_settings(
+                block_id,
+                vec![String::from("sawtooth.consensus.raft.peers")],
+            )
             .expect("Failed to get settings");
         let peers = get_peers_from_settings(&settings);
         let peers: HashSet<PeerId> = HashSet::from_iter(peers);
 
         // Check if membership has changed
-        let old_peers: HashSet<PeerId> = HashSet::from_iter(self.raft_id_to_peer_id.values().cloned());
+        let old_peers: HashSet<PeerId> =
+            HashSet::from_iter(self.raft_id_to_peer_id.values().cloned());
         let difference: HashSet<PeerId> = peers.symmetric_difference(&old_peers).cloned().collect();
 
         if !difference.is_empty() {
@@ -386,7 +434,10 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
 
             // The raft-rs library can only add or delete one node at a time, so there should
             // only be one item in this iterator
-            let peer_id = difference.iter().nth(0).expect("Difference cannot be empty here.");
+            let peer_id = difference
+                .iter()
+                .nth(0)
+                .expect("Difference cannot be empty here.");
             // Initialize change
             let mut change = ConfChange::new();
             change.set_node_id(peer_id_to_raft_id(&peer_id));
@@ -400,7 +451,10 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
                 change.set_change_type(ConfChangeType::RemoveNode);
             }
 
-            info!("Leader({:?}) detected configuration change {:?}", self.peer_id, change);
+            info!(
+                "Leader({:?}) detected configuration change {:?}",
+                self.peer_id, change
+            );
             return Some(change);
         }
 
@@ -420,13 +474,11 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
                 }
 
                 self.raft_id_to_peer_id.remove(&raft_id).unwrap();
-            },
+            }
             ConfChangeType::AddNode => {
-                self.raft_id_to_peer_id.insert(
-                    raft_id,
-                    PeerId::from(Vec::from(change.get_context()))
-                );
-            },
+                self.raft_id_to_peer_id
+                    .insert(raft_id, PeerId::from(Vec::from(change.get_context())));
+            }
             _ => {}
         }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -15,7 +15,11 @@
  * ------------------------------------------------------------------------------
  */
 
-use raft::{Error, eraftpb::{ConfState, Entry, HardState, Snapshot}, storage::{MemStorage, Storage}};
+use raft::{
+    eraftpb::{ConfState, Entry, HardState, Snapshot},
+    storage::{MemStorage, Storage},
+    Error,
+};
 
 /// Extends the storage trait to include methods used by SawtoothRaftNode and provided by the
 /// MemStorage type.
@@ -62,9 +66,10 @@ impl StorageExt for MemStorage {
         cs: Option<&ConfState>,
         data: Vec<u8>,
     ) -> Result<Snapshot, Error> {
-        self.wl().create_snapshot(idx, cs.map(ConfState::clone), data).map(Snapshot::clone)
+        self.wl()
+            .create_snapshot(idx, cs.map(ConfState::clone), data)
+            .map(Snapshot::clone)
     }
-
 
     fn apply_snapshot(&self, snapshot: &Snapshot) -> Result<(), Error> {
         self.wl().apply_snapshot(snapshot.clone())
@@ -93,11 +98,14 @@ impl StorageExt for MemStorage {
 }
 
 #[cfg(test)]
-pub (crate) mod tests {
+pub(crate) mod tests {
     use super::*;
 
     use raft::{
-        self, storage::MemStorage, eraftpb::{ConfState, Entry, HardState}, RaftState, Storage,
+        self,
+        eraftpb::{ConfState, Entry, HardState},
+        storage::MemStorage,
+        RaftState, Storage,
     };
 
     const MAX: u64 = u64::max_value();
@@ -118,7 +126,6 @@ pub (crate) mod tests {
         storage.append(&entries).unwrap();
         entries
     }
-
 
     // Storage trait tests
 
@@ -151,7 +158,7 @@ pub (crate) mod tests {
         for i in 1..4 {
             for j in i..4 {
                 assert_eq!(
-                    Ok(entries[i-1..j-1].to_vec()),
+                    Ok(entries[i - 1..j - 1].to_vec()),
                     storage.entries(i as u64, j as u64, MAX)
                 );
             }
@@ -202,7 +209,6 @@ pub (crate) mod tests {
         assert_eq!(Ok(4), storage.first_index());
         assert_eq!(Ok(5), storage.last_index());
     }
-
 
     // StorageExt trait tests
 
@@ -277,8 +283,12 @@ pub (crate) mod tests {
 
         assert_eq!(mem_storage.snapshot(), storage.snapshot());
 
-        let mem_snapshot = mem_storage.create_snapshot(3, None, "".into()).expect("MemStorage: Create snapshot failed");
-        let fs_snapshot = storage.create_snapshot(3, None, "".into()).expect("FsStorage: Create snapshot failed");
+        let mem_snapshot = mem_storage
+            .create_snapshot(3, None, "".into())
+            .expect("MemStorage: Create snapshot failed");
+        let fs_snapshot = storage
+            .create_snapshot(3, None, "".into())
+            .expect("FsStorage: Create snapshot failed");
         assert_eq!(mem_snapshot, fs_snapshot);
 
         assert_eq!(

--- a/src/ticker.rs
+++ b/src/ticker.rs
@@ -15,7 +15,7 @@
  * ------------------------------------------------------------------------------
  */
 
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 /// Encapsulates doing some work every time a timeout has elapsed
 pub struct Ticker {


### PR DESCRIPTION
1. Follow default warning level check for clippy.
2. Added lint checks as part of Jenkinsfile.
3. Fix clippy warnings and fmt issues in sawtooth-raft.