### PR TITLE
State machine correction for sawtooth-raft

### DIFF
--- a/src/block_queue.rs
+++ b/src/block_queue.rs
@@ -89,14 +89,12 @@ impl BlockQueue {
     }
 
     // Returns the BlockId of the next block that can be committed (if there is one)
-    pub fn get_next_committable(&mut self, chain_head: &Block) -> Option<BlockId> {
+    pub fn get_next_committable(&mut self) -> Option<BlockId> {
         if let Some(&(ref block_id, _)) = self.commit_queue.front() {
             if let Some(status) = self.validator_backlog.get(block_id) {
-                if let Some(block) = status.block.clone() {
-                    if status.block_valid && block.previous_id == chain_head.block_id {
-                        // Block is ready
-                        return Some(block_id.clone());
-                    }
+                if status.block_valid {
+                    // Block is ready
+                    return Some(block_id.clone());
                 }
             }
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -331,10 +331,7 @@ impl<S: StorageExt> SawtoothRaftNode<S> {
         }
 
         // Commit next committable block from backlog (if there is one)
-        let chain_head = self.service
-            .get_chain_head()
-            .expect("Chain head should not be none");
-        if let Some(block_id) = self.block_queue.get_next_committable(&chain_head) {
+        if let Some(block_id) = self.block_queue.get_next_committable() {
             self.commit_block(&block_id);
         };
 


### PR DESCRIPTION
A leader node in sawtooth-raft asks validator to commit a block
when majority of the follower nodes replicated the log entry.
However follower nodes may lose the log commit confirmation
from the leader node. Majority of the follower nodes form a
group and elect a new leader.

A log entry is safe committed as per raft if majority of the
nodes have the log stored and at least one entry from the
leaders term is also majority stored.

If majority of the nodes continue adding blocks, the old
leader has to replace the log entry. This is taken care by raft.
However block already added to the blockchain shall also get
replaced with the new one.

Order of the nodes added to blockchain is controlled by deque.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>