### PR TITLE
 Add COMPOSE_PROJECT_NAME to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,7 @@ pipeline {
 
     environment {
         ISOLATION_ID = sh(returnStdout: true, script: 'printf $BUILD_TAG | sha256sum | cut -c1-64').trim()
+        COMPOSE_PROJECT_NAME = sh(returnStdout: true, script: 'printf $BUILD_TAG | sha256sum | cut -c1-64').trim()
     }
 
     stages {


### PR DESCRIPTION
This variable prevents naming collisions in containers created by
docker-compose. This variable was missing from the Jenkinsfile rewrite.

Signed-off-by: Richard Berg <rberg@bitwise.io>