### PR TITLE
Retire Inactive Maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @aludvik @dcmiddle @jsmitchell @ltseeley @peterschwarz @vaporos
+*       @agunde406 @dcmiddle @jsmitchell @ltseeley @peterschwarz @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,16 @@
+## Maintainers
+
+### Active Maintainers
 | Name | GitHub | RocketChat |
 | --- | --- | --- |
-| Adam Ludvik | aludvik | adamludvik |
 | Andi Gunderson | agunde406 | agunde |
 | Dan Middleton | dcmiddle | Dan |
 | James Mitchell | jsmitchell | jsmitchell |
 | Logan Seeley | ltseeley | ltseeley |
 | Peter Schwarz | peterschwarz | pschwarz |
 | Shawn Amundson | vaporos | amundson |
+
+### Retired Maintainers
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Adam Ludvik | aludvik | adamludvik |


### PR DESCRIPTION
Adam Ludvik has requested to be retired.

As described in the Sawtooth Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.