### PR TITLE
Propose new maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @dcmiddle @jsmitchell @ltseeley @peterschwarz @vaporos
+*       @agunde406 @dcmiddle @jsmitchell @ltseeley @peterschwarz @rberg2 @rbuysse @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,8 @@
 | James Mitchell | jsmitchell | jsmitchell |
 | Logan Seeley | ltseeley | ltseeley |
 | Peter Schwarz | peterschwarz | pschwarz |
+| Richard Berg | rberg2 | rberg2 |
+| Ryan Beck-Buysse | rbuysse | rbuysse |
 | Shawn Amundson | vaporos | amundson |
 
 ### Retired Maintainers


### PR DESCRIPTION
Add Richard Berg and Ryan Beck-Buysse to maintainers.

As described in the Sawtooth Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.