### PR TITLE
Fix versioning of raft-engine package

### DIFF
--- a/Dockerfile-installed-bionic
+++ b/Dockerfile-installed-bionic
@@ -46,8 +46,9 @@ COPY . /project/sawtooth-raft
 
 WORKDIR /project/sawtooth-raft
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(./bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== raft docker build ===-------------
 FROM ubuntu:bionic

--- a/Dockerfile-installed-xenial
+++ b/Dockerfile-installed-xenial
@@ -46,8 +46,9 @@ COPY . /project/sawtooth-raft
 
 WORKDIR /project/sawtooth-raft
 
-RUN sed -i -e s/version.*$/version\ =\ \"$(bin/get_version)\"/ Cargo.toml
-RUN /root/.cargo/bin/cargo deb
+RUN export VERSION=$(./bin/get_version) \
+ && sed -i -e s/version.*$/version\ =\ \"${VERSION}\"/ Cargo.toml \
+ && /root/.cargo/bin/cargo deb --deb-version $VERSION
 
 # -------------=== raft docker build ===-------------
 FROM ubuntu:xenial


### PR DESCRIPTION
The behavior of cargo-deb was changed to generate version numbers with
tildes instead of dashes. This is causing newly built packages to sort
below older releases.

https://github.com/mmstick/cargo-deb/pull/102

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>